### PR TITLE
Fix connection failures by updating API version and headers

### DIFF
--- a/src/MsEdgeTTS.ts
+++ b/src/MsEdgeTTS.ts
@@ -93,7 +93,7 @@ export class MsEdgeTTS {
     private static async getSynthUrl(): Promise<string> {
         const req_id = MsEdgeTTS.generateUUID(); // Generate the request ID
         const secMsGEC = await MsEdgeTTS.generateSecMsGec(this.TRUSTED_CLIENT_TOKEN);
-        return `${this.WSS_URL}?TrustedClientToken=${this.TRUSTED_CLIENT_TOKEN}&Sec-MS-GEC=${secMsGEC}&Sec-MS-GEC-Version=1-130.0.2849.68&ConnectionId=${req_id}`;
+        return `${this.WSS_URL}?TrustedClientToken=${this.TRUSTED_CLIENT_TOKEN}&Sec-MS-GEC=${secMsGEC}&Sec-MS-GEC-Version=1-143.0.3650.96&ConnectionId=${req_id}`;
     }
 
     private static generateUUID(): string {
@@ -134,9 +134,16 @@ export class MsEdgeTTS {
 
     private async _initClient() {
         const synthUrl = await MsEdgeTTS.getSynthUrl();
+        const options = {
+            agent: this._agent,
+            headers: {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0",
+                "Origin": "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold"
+            }
+        };
         this._ws = this._isBrowser
             ? new WebSocket(synthUrl)
-            : new WebSocket(synthUrl, {agent: this._agent})
+            : new WebSocket(synthUrl, options)
 
         this._ws.binaryType = "arraybuffer"
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
**Description:**
This PR fixes an issue where the library was no longer able to connect to the Microsoft Edge TTS service due to API changes.

Resolves: https://github.com/Migushthe2nd/MsEdgeTTS/issues/26

**Changes:**
*   **Updated API Version:** Bumped the `Sec-MS-GEC-Version` query parameter in `getSynthUrl` from `1-130.0.2849.68` to `1-143.0.3650.96`.
*   **Added Headers:** Implemented `User-Agent` and `Origin` headers in the `_initClient` method when establishing the WebSocket connection.

**Verification:**
Verified that the library can successfully connect and synthesize audio with these changes applied. Without these updates, the connection fails immediately.