### PR TITLE
Wrap remaining toFile() rejects in Error instances

### DIFF
--- a/src/MsEdgeTTS.spec.ts
+++ b/src/MsEdgeTTS.spec.ts
@@ -93,7 +93,7 @@ describe("MsEdgeTTS", () => {
         // mock _pushAudioData to do nothing, asif no data was received
         tts["_pushAudioData"] = jest.fn()
         await expect(() => tts.toFile(tmpPath, ""))
-            .rejects.toMatch("No audio")
+            .rejects.toThrow("No audio data received")
 
         expect(Object.keys(tts["_streams"]).length).toBe(0)
         expect(existsSync(join(tmpPath, "audio." + OUTPUT_EXTENSIONS[tts["_outputFormat"]]))).toBe(false)

--- a/src/MsEdgeTTS.ts
+++ b/src/MsEdgeTTS.ts
@@ -377,7 +377,7 @@ export class MsEdgeTTS {
                         if (writableAudioFile.bytesWritten > 0) {
                             resolve(audioFilePath)
                         } else {
-                            reject("No audio data received")
+                            reject(new Error("No audio data received"))
                             fs.unlinkSync(audioFilePath)
                         }
                     })
@@ -400,7 +400,7 @@ export class MsEdgeTTS {
                             fs.writeFileSync(metadataFilePath, JSON.stringify(metadataItems, null, 2))
                             resolve(metadataFilePath)
                         } else {
-                            reject("No metadata received")
+                            reject(new Error("No metadata received"))
                             fs.unlinkSync(metadataFilePath)
                         }
                     })


### PR DESCRIPTION
Follow-up to 2.0.5's `onerror` fix. The two remaining string rejects in `toFile()` get wrapped in `new Error(...)` so callers get a proper Error (stack, `instanceof`, structured logging).

Also updates the `should not write to file if no data` test from `.rejects.toMatch("No audio")` to `.rejects.toThrow("No audio data received")` — `toMatch` is for string rejects, `toThrow` is the right matcher for Errors and also asserts `instanceof Error`.

Fixes #32.